### PR TITLE
Bump .NET version to .NET 10

### DIFF
--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          8.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Create packages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          8.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Run tests

--- a/Contracts.ASP.Client/Contracts.ASP.Client.csproj
+++ b/Contracts.ASP.Client/Contracts.ASP.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Contracts.ASP.Server/Contracts.ASP.Server.csproj
+++ b/Contracts.ASP.Server/Contracts.ASP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Contracts.ASP/Contracts.ASP.csproj
+++ b/Contracts.ASP/Contracts.ASP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Contracts.Abstractions/Contracts.Abstractions.csproj
+++ b/Contracts.Abstractions/Contracts.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Contracts.Tests/Contracts.Tests.csproj
+++ b/Contracts.Tests/Contracts.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/TestContract/TestContract.csproj
+++ b/TestContract/TestContract.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/TestServer/TestServer.csproj
+++ b/TestServer/TestServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Upgrades this repository from .NET 6/8 to **.NET 10** (`net10.0`).

**Changes:**
- Updated `TargetFramework(s)` in all project files to `net10.0`.
- Bumped the `setup-dotnet` version pin in CI workflows to `10.0.x`.

Builds cleanly against the .NET 10 SDK.